### PR TITLE
Fix value error caused by new Rasdaman time format

### DIFF
--- a/owslib/coverage/wcs200.py
+++ b/owslib/coverage/wcs200.py
@@ -284,6 +284,7 @@ class ContentMetadata(object):
                    cooeficients = elem.find('{http://www.opengis.net/gml/3.3/rgrid}GeneralGridAxis/{http://www.opengis.net/gml/3.3/rgrid}coefficients').text.split(' ')
             for x in cooeficients:
                 #t_pos = int(start_pos) + int(x)
+                x = x.replace('"', '')
                 t_date = datetime_from_iso(x)
                 timepositions.append(t_date)
         else:

--- a/owslib/util.py
+++ b/owslib/util.py
@@ -664,8 +664,12 @@ def findall(root, xpath, attribute_name=None, attribute_value=None):
 
 
 def datetime_from_iso(iso):
-    """returns a datetime object from dates in the format 2001-07-01T00:00:00Z """
-    return datetime.strptime(iso, "%Y-%m-%dT%H:%M:%SZ")
+    """returns a datetime object from dates in the format 2001-07-01T00:00:00Z or 2001-07-01T00:00:00.000Z """
+    try:
+        iso_datetime = datetime.strptime(iso, "%Y-%m-%dT%H:%M:%SZ")
+    except:
+        iso_datetime = datetime.strptime(iso, "%Y-%m-%dT%H:%M:%S.%fZ")
+    return iso_datetime
 
 def datetime_from_ansi(ansi):
     """Converts an ansiDate (expressed as a number = the nuber of days since the datum origin of ansi) to a python datetime object."""


### PR DESCRIPTION
As the new version of Rasdaman changed its ISO timeformat by adding microseconds, a value error is thrown when using wcs.contents['$coverage'].timepositions
This is a quick fix, that works with the old and the new timeformat. 